### PR TITLE
Work correctly also if PATH contains spaces

### DIFF
--- a/resources/files/puppet-agent.sh
+++ b/resources/files/puppet-agent.sh
@@ -1,6 +1,6 @@
 # Add /opt/puppetlabs/bin to the path for sh compatible users
 
-if [ -z ${PATH-} ] ; then
+if [ -z "${PATH-}" ] ; then
   export PATH=/opt/puppetlabs/bin
 elif ! echo ${PATH} | grep -q /opt/puppetlabs/bin ; then
   export PATH=${PATH}:/opt/puppetlabs/bin


### PR DESCRIPTION
Not maybe a very common case in general, but for example easy to spot when in WSL.